### PR TITLE
Fix encoding exception by explicitely using UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.6.5
+
+ENV LANG C.UTF-8
+
+WORKDIR /usr/src/app
+
+COPY Gemfile ./
+RUN bundle install
+
+COPY . .

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 # Gemfile
 
+source 'https://rubygems.org'
+
 gem 'i18n'
 gem 'kimurai'
 gem 'mechanize'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bundle exec rake help
 
 ```bash
 $ docker build --rm -t suministrospr-web-scraper .
-$ docker run -it --rm suministrospr-web-scraper bundle exec rake boom
+$ docker run -it --rm -v "$PWD":/usr/src/app suministrospr-web-scraper bundle exec rake boom
 ```
 
 ## Data

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ For help, type:
 bundle exec rake help
 ```
 
+### Docker
+
+```bash
+$ docker build --rm -t suministrospr-web-scraper .
+$ docker run -it --rm suministrospr-web-scraper bundle exec rake boom
+```
+
 ## Data
 
 Each post found at [SuministrosPR.com](https://SuministrosPR.com) will be saved under the `./data` directory as an individual `JSON` file.


### PR DESCRIPTION
Was eventually running into the following exception when running:

```
F, [2020-01-15 01:40:38 +0000#1] [M: 46914900441460] FATAL -- suministrospr-web-scraper: Spider: stopped: {:spider_name=>"suministrospr-web-scraper", :status=>:failed, :error=>"#<ArgumentError: invalid byte sequence in US-ASCII>", :environment=>"development", :start_time=>2020-01-15 01:40:34 +0000, :stop_time=>2020-01-15 01:40:38 +0000, :running_time=>"3s", :visits=>{:requests=>3, :responses=>3}, :items=>{:sent=>0, :processed=>0}, :events=>{:requests_errors=>{}, :drop_items_errors=>{}, :custom=>{}}}
rake aborted!
ArgumentError: invalid byte sequence in US-ASCII
```

These changes introduce a way for running this tool with Docker. It also fixes the exception by explicitly using a UTF-8 locale.